### PR TITLE
PR changes

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -16,7 +16,9 @@ interface RouteProps {
 
 const ValidatedRoute = ({ component: Component, ...rest }: RouteProps): ReactElement => {
   const { config } = useContext(ConfigContext);
-  return <Route {...rest} render={props => (!isEmpty(config) ? <Component {...props} /> : <Redirect to="/" />)} />;
+  //update with config authentication to access the route
+  const isValidated = !isEmpty(config) && config.formSchema.length > 0;
+  return <Route {...rest} render={props => (isValidated ? <Component {...props} /> : <Redirect to="/" />)} />;
 };
 
 export const Routes = (): ReactElement => (

--- a/src/components/ConfigDropzone/index.tsx
+++ b/src/components/ConfigDropzone/index.tsx
@@ -7,7 +7,7 @@ import { css } from "@emotion/core";
 import styled from "@emotion/styled";
 import { getLogger } from "../../logger";
 import { readFileData } from "../utils/file";
-import { getInitialFormData } from "../utils/config";
+import { getDocumentMetaData } from "../utils/config";
 
 const { trace } = getLogger("components/ConfigDropzone");
 
@@ -47,8 +47,8 @@ const ConfigDropzoneContainer = (): ReactElement => {
   const history = useHistory();
   const processConfigUpdate = (configFile: any): void => {
     setConfig(configFile);
-    const initialFormData = getInitialFormData(configFile);
-    setDocumentsList([initialFormData]);
+    const documentMeta = getDocumentMetaData(configFile);
+    setDocumentsList([documentMeta]);
     history.push("/form");
   };
 

--- a/src/components/ConfigDropzone/index.tsx
+++ b/src/components/ConfigDropzone/index.tsx
@@ -1,13 +1,11 @@
 import React, { useContext, ReactElement } from "react";
 import { useHistory } from "react-router-dom";
 import { ConfigContext } from "../../contexts/ConfigurationContext";
-import { FormDataContext } from "../../contexts/FormDataContext";
 import Dropzone from "react-dropzone";
 import { css } from "@emotion/core";
 import styled from "@emotion/styled";
 import { getLogger } from "../../logger";
 import { readFileData } from "../utils/file";
-import { getDocumentMetaData } from "../utils/config";
 
 const { trace } = getLogger("components/ConfigDropzone");
 
@@ -42,13 +40,10 @@ const SelectButton = styled.button`
 
 const ConfigDropzoneContainer = (): ReactElement => {
   const { config, setConfig } = useContext(ConfigContext);
-  const { setDocumentsList } = useContext(FormDataContext);
 
   const history = useHistory();
   const processConfigUpdate = (configFile: any): void => {
     setConfig(configFile);
-    const documentMeta = getDocumentMetaData(configFile);
-    setDocumentsList([documentMeta]);
     history.push("/form");
   };
 

--- a/src/components/ConfigDropzone/index.tsx
+++ b/src/components/ConfigDropzone/index.tsx
@@ -42,13 +42,13 @@ const SelectButton = styled.button`
 
 const ConfigDropzoneContainer = (): ReactElement => {
   const { config, setConfig } = useContext(ConfigContext);
-  const { setDocumentMeta } = useContext(FormDataContext);
+  const { setDocumentsList } = useContext(FormDataContext);
 
   const history = useHistory();
   const processConfigUpdate = (configFile: any): void => {
     setConfig(configFile);
     const initialFormData = getInitialFormData(configFile);
-    setDocumentMeta([initialFormData]);
+    setDocumentsList([initialFormData]);
     history.push("/form");
   };
 

--- a/src/components/FormDisplay/UploadDataView.tsx
+++ b/src/components/FormDisplay/UploadDataView.tsx
@@ -2,16 +2,16 @@ import React, { useContext, ReactElement } from "react";
 import { readFileData } from "../utils/file";
 import { FormDataContext } from "../../contexts/FormDataContext";
 import { ConfigContext } from "../../contexts/ConfigurationContext";
-import { getInitialFormData } from "../utils/config";
+import { getDocumentMetaData } from "../utils/config";
 
 export const UploadDataView = (): ReactElement => {
   const { setDocumentsList } = useContext(FormDataContext);
   const { config } = useContext(ConfigContext);
-  const initialFormData = getInitialFormData(config);
+  const documentMeta = getDocumentMetaData(config);
 
-  const updateFormData = (uploadedData: Document[]): void => {
-    const mergedDataSet = uploadedData.map((data: object) => ({ ...data, ...initialFormData }));
-    setDocumentsList(mergedDataSet);
+  const updateFormData = (uploadedFormData: Document[]): void => {
+    const mergedDocumentsSet = uploadedFormData.map((formData: Document) => ({ ...formData, ...documentMeta }));
+    setDocumentsList(mergedDocumentsSet);
   };
   const handleFileUpload = (e: any): void => {
     readFileData([...e.target.files], updateFormData);

--- a/src/components/FormDisplay/UploadDataView.tsx
+++ b/src/components/FormDisplay/UploadDataView.tsx
@@ -5,13 +5,13 @@ import { ConfigContext } from "../../contexts/ConfigurationContext";
 import { getInitialFormData } from "../utils/config";
 
 export const UploadDataView = (): ReactElement => {
-  const { setDocumentMeta } = useContext(FormDataContext);
+  const { setDocumentsList } = useContext(FormDataContext);
   const { config } = useContext(ConfigContext);
   const initialFormData = getInitialFormData(config);
 
   const updateFormData = (uploadedData: Document[]): void => {
     const mergedDataSet = uploadedData.map((data: object) => ({ ...data, ...initialFormData }));
-    setDocumentMeta(mergedDataSet);
+    setDocumentsList(mergedDataSet);
   };
   const handleFileUpload = (e: any): void => {
     readFileData([...e.target.files], updateFormData);

--- a/src/components/FormDisplay/index.tsx
+++ b/src/components/FormDisplay/index.tsx
@@ -13,24 +13,24 @@ const HeaderDiv = styled.div`
 `;
 
 const FormDisplay = (): ReactElement => {
-  const { documentsMeta, setDocumentMeta, setWrappedDocument } = useContext(FormDataContext);
-  const [activeTab] = useState(0);
+  const { documentsList, setDocumentsList, setDocument } = useContext(FormDataContext);
+  const [activeTab] = useState(0); //Add setActiveTab method to update it when handling multitab
   const { config } = useContext(ConfigContext);
 
-  const handleSubmit = (formValues: Document): void => {
-    documentsMeta.splice(activeTab, 1, formValues);
-    setDocumentMeta(documentsMeta);
-    setWrappedDocument(formValues);
+  const handleSubmit = (document: Document): void => {
+    documentsList.splice(activeTab, 1, document);
+    setDocumentsList(documentsList);
+    setDocument(document);
   };
 
   return (
     <>
       <HeaderDiv id="form-header" className="container">
-        {documentsMeta[activeTab] && <DisplayPreview document={documentsMeta[activeTab]} />}
+        {documentsList[activeTab] && <DisplayPreview document={documentsList[activeTab]} />}
         <UploadDataView />
       </HeaderDiv>
       <div id="form-body" className="container p-2 bg-light">
-        <JsonSchemaForm formSchema={config.formSchema} formData={documentsMeta} onSubmit={handleSubmit} />
+        <JsonSchemaForm formSchema={config.formSchema} formData={documentsList} onSubmit={handleSubmit} />
       </div>
     </>
   );

--- a/src/components/utils/config.ts
+++ b/src/components/utils/config.ts
@@ -1,7 +1,7 @@
 import { get } from "lodash";
 import { Config, DocumentMeta } from "../../types";
 
-export const getInitialFormData = (config: Config): DocumentMeta => {
+export const getDocumentMetaData = (config: Config): DocumentMeta => {
   const document = get(config, "documentMeta");
   return document;
 };

--- a/src/contexts/ConfigurationContext/index.tsx
+++ b/src/contexts/ConfigurationContext/index.tsx
@@ -1,45 +1,52 @@
 import React, { ReactElement } from "react";
 import { Config } from "../../types";
 
-interface Props {
+interface ConfigProviderProps {
   children: ReactElement;
 }
 
-export const ConfigContext = React.createContext({
-  config: {
-    application: {
-      wallet: {},
-      network: "ethereum-ropsten"
-    },
-    documentMeta: {
-      name: "",
-      $template: {
-        name: "",
-        type: "EMBEDDED_RENDERER",
-        url: ""
-      },
-      issuers: [
-        {
-          name: "",
-          tokenRegistry: "",
-          identityProof: {
-            type: "DNS-TXT",
-            location: ""
-          }
-        }
-      ]
-    },
-    formSchema: []
+interface ConfigProviderState {
+  config: Config;
+  setConfig: (config: Config) => void;
+}
+
+const initialConfig = {
+  application: {
+    wallet: {},
+    network: "ethereum-ropsten"
   },
+  documentMeta: {
+    name: "",
+    $template: {
+      name: "",
+      type: "EMBEDDED_RENDERER",
+      url: ""
+    },
+    issuers: [
+      {
+        name: "",
+        tokenRegistry: "",
+        identityProof: {
+          type: "DNS-TXT",
+          location: ""
+        }
+      }
+    ]
+  },
+  formSchema: []
+};
+
+export const ConfigContext = React.createContext<ConfigProviderState>({
+  config: initialConfig,
   setConfig: (config: Config) => config
 });
 
-export class ConfigProvider extends React.Component {
-  constructor(props: Props) {
+export class ConfigProvider extends React.Component<ConfigProviderProps, ConfigProviderState> {
+  constructor(props: ConfigProviderProps) {
     super(props);
     this.state = {
-      config: {},
-      setConfig: (config: any) => {
+      config: initialConfig,
+      setConfig: (config: Config) => {
         this.setState(prevState => {
           return { ...prevState, config };
         });

--- a/src/contexts/FormDataContext/index.tsx
+++ b/src/contexts/FormDataContext/index.tsx
@@ -1,31 +1,38 @@
 import React, { ReactElement } from "react";
 import { issueDocument } from "@govtechsg/tradetrust-schema";
-import { Document } from "@govtechsg/decentralized-renderer-react-components";
+import { Document, SignedDocument } from "@govtechsg/decentralized-renderer-react-components";
 
-export const FormDataContext = React.createContext({
-  documentsMeta: [],
-  setDocumentMeta: (documentsMeta: Document[]) => documentsMeta,
+interface FormDataState {
+  documentsList: Array<Document>;
+  setDocumentsList: (documentsList: Document[]) => void;
+  wrappedDocument: Partial<SignedDocument<any>>;
+  setDocument: (document: Document) => void;
+}
+
+export const FormDataContext = React.createContext<FormDataState>({
+  documentsList: [],
+  setDocumentsList: (documentsList: Document[]) => documentsList,
   wrappedDocument: {},
-  setWrappedDocument: (wrappedDocument: Document) => wrappedDocument
+  setDocument: (document: Document) => document
 });
 
 interface FormDataProps {
   children: ReactElement;
 }
 
-export class FormDataProvider extends React.Component {
+export class FormDataProvider extends React.Component<FormDataProps, FormDataState> {
   constructor(props: FormDataProps) {
     super(props);
     this.state = {
-      documentsMeta: [],
+      documentsList: [],
       wrappedDocument: {},
-      setDocumentMeta: (documentsMeta: Document[]) => {
+      setDocumentsList: (documentsList: Document[]) => {
         this.setState(prevState => {
-          return { ...prevState, documentsMeta };
+          return { ...prevState, documentsList };
         });
       },
-      setWrappedDocument: (documentMeta: Document) => {
-        const wrappedDocument = issueDocument(documentMeta);
+      setDocument: (document: Document) => {
+        const wrappedDocument = issueDocument(document);
         this.setState(prevState => {
           return { ...prevState, wrappedDocument };
         });

--- a/src/contexts/Web3Context/index.tsx
+++ b/src/contexts/Web3Context/index.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { ethers, providers } from "ethers";
 import { getWeb3FromEnvironment } from "./utils";
 import { getLogger } from "../../logger";
+import { EncryptedJsonWallet } from "../../types";
 
 const { trace } = getLogger("Web3Context");
 
@@ -16,28 +17,6 @@ export interface Web3ContextProps {
 // @ts-ignore: this context is not supposed to be used separately from the provider component below so the defaultValue will never be used
 export const Web3Context = React.createContext<Web3ContextProps>();
 
-interface EncryptedJsonWallet {
-  // commonplace web3 encrypted wallet object shape, geth parity etc
-  address: string;
-  id: string;
-  version: number;
-  Crypto: {
-    cipher: string;
-    cipherparams: {
-      iv: string;
-    };
-    ciphertext: string;
-    kdf: string;
-    kdfparams: {
-      salt: string;
-      n: number;
-      dklen: number;
-      p: number;
-      r: number;
-    };
-    mac: string;
-  };
-}
 export class Web3Provider extends React.Component<any, Web3ContextProps> {
   constructor(props: any) {
     super(props);

--- a/src/test/documentPreview.spec.ts
+++ b/src/test/documentPreview.spec.ts
@@ -1,6 +1,6 @@
 import { Selector } from "testcafe";
 
-fixture("Schema Form Rendering").page`http://localhost:3010`; // eslint-disable-line mdx/no-unused-expressions
+fixture("Form Preview View").page`http://localhost:3010`; // eslint-disable-line mdx/no-unused-expressions
 
 const Config = "./fixture/config.json";
 const Data = "./fixture/formData.json";
@@ -13,8 +13,14 @@ const SampleTemplate = Selector("#root");
 const validateTextContent = async (t: TestController, component: Selector, texts: string[]): Promise<any> =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
-/* eslint-disable jest/expect-expect, jest/require-top-level-describe, jest/no-test-callback */
-test("form preview is rendered correctly", async (t: TestController) => {
+/* 
+  1. jest/expect-expect - already extracted out in common method on top to match the expect.
+  2. jest/require-top-level-describe - We already have description in fixture and then test description.
+  3. jest/no-test-callback - this rule adding extra Promise which stops the execution of the tests. 
+*/
+
+/*eslint-disable jest/expect-expect, jest/require-top-level-describe, jest/no-test-callback */
+test("form preview is rendered correctly with correct data", async (t: TestController) => {
   await t.setFilesToUpload("input[type=file]", [Config]);
   await FormHeader.with({ visibilityCheck: true })();
   await t.setFilesToUpload("input[type=file]", [Data]);

--- a/src/test/jsonSchemaRendering.spec.ts
+++ b/src/test/jsonSchemaRendering.spec.ts
@@ -10,8 +10,13 @@ const FormBody = Selector("#form-body");
 const validateTextContent = async (t: TestController, component: Selector, texts: string[]): Promise<any> =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
+/* 
+  1. jest/expect-expect - already extracted out in common method on top to match the expect.
+  2. jest/require-top-level-describe - We already have description in fixture and then test description.
+  3. jest/no-test-callback - this rule adding extra Promise which stops the execution of the tests. 
+*/
 /* eslint-disable jest/expect-expect, jest/require-top-level-describe, jest/no-test-callback */
-test("config schema is rendered correctly", async (t: TestController) => {
+test("config schema is rendered correctly to display form", async (t: TestController) => {
   const container = Selector("#document-dropzone");
   await container();
   await validateTextContent(t, DropzoneContainer, ["Drag 'n' drop TradeTrust configuration file here"]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,29 @@
 import { FormProps } from "react-jsonschema-form";
 type JsonSchema = FormProps<any>["schema"];
 
+export interface EncryptedJsonWallet {
+  // commonplace web3 encrypted wallet object shape, geth parity etc
+  address: string;
+  id: string;
+  version: number;
+  Crypto: {
+    cipher: string;
+    cipherparams: {
+      iv: string;
+    };
+    ciphertext: string;
+    kdf: string;
+    kdfparams: {
+      salt: string;
+      n: number;
+      dklen: number;
+      p: number;
+      r: number;
+    };
+    mac: string;
+  };
+}
+
 export type DocumentMeta = {
   name: string;
   $template: {
@@ -20,7 +43,7 @@ export type DocumentMeta = {
 
 export interface Config {
   application: {
-    wallet: object;
+    wallet: Partial<EncryptedJsonWallet>;
     network: string;
   };
   documentMeta: DocumentMeta;


### PR DESCRIPTION
- Added comments for eslint disbled rules in test
- Extracted wallet typeto common
-  Fixed naming of the formDataContext method and variables.

For the comment - 

L21: no idea what happens when the indices on the tab don't match the length of the array -> i'd rather you just hardcode the array and leave a comment if we aren't dealing with multitab right now, because otherwise we might miss and cause a bug in the future

- I have set the initial value of activeTab to 0. and its not getting updated any where for now. will be used later when multi tab will be supported 

L22: what's documentsMeta supposed to contain in the form data context? i thought meta just comes directly from the config? why's this an array and wrappedDocument a single object?
- My mistake. fixed the name to documentsMeta =>  documentsList.  its an array because there could be multiple data set from a single file for a schema. wrappedDocument is single object because we will sign only one document at a time. 

L23: when the method is named setWrappedDocument i expect that it's taking in a WrappedDocument and then simply setting that - what's actually happening here is that it's taking a Document and then wrapping it -> just name it setDocument. the parameter name is confusing as well
- Fixed. Named its setDocument and passed document as a param name. 